### PR TITLE
Feature/add openapi plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 "typer>=0.12",
 "jinja2>=3.1",
 "rich>=13.7",
+"flask_smorest>=0.41.0",
 ]
 
 [project.optional-dependencies]

--- a/src/forge/cli.py
+++ b/src/forge/cli.py
@@ -35,12 +35,14 @@ from jinja2 import Environment, FileSystemLoader
 from .commands.run_cmd import run as run_cmd
 from .commands.db_cmd import db as db_cmd
 from .commands.generate_cmd import generate as generate_cmd
+from .commands.plugin_cmd import plugin
 from .utils.fs import ensure_init_files
 
 app = typer.Typer(help="Forge – Clean Architecture Flask scaffolding CLI")
 app.add_typer(run_cmd, name="run")
 app.add_typer(db_cmd, name="db")
 app.add_typer(generate_cmd, name="generate")
+app.add_typer(plugin, name="plugin")
 
 # Default template to use for new projects
 TEMPLATE = "clean"

--- a/src/forge/commands/generate_cmd.py
+++ b/src/forge/commands/generate_cmd.py
@@ -282,7 +282,7 @@ def test_http_smoke():
     pkg = import_module("{pkg}")
     app = pkg.create_app()
     c = app.test_client()
-    r = c.post("/api/{name}", json={"name": "X"})
+    r = c.post("/api/{name}", json={'name': 'X'})
     assert r.status_code == 201
     r = c.get("/api/{name}")
     assert r.status_code == 200

--- a/src/forge/commands/generate_cmd.py
+++ b/src/forge/commands/generate_cmd.py
@@ -269,7 +269,7 @@ def test_sqlalchemy_repo_roundtrip(tmp_path):
     Base.metadata.create_all(bind=engine)
 
     repo = SqlAlchemy{Entity}Repository(Session)
-    one = repo.add(type("E", (), {"id": None, "name": "X"}))
+    one = repo.add(type("E", (), {'id': None, 'name': 'X'}))
     assert one.id is not None
     assert [x.name for x in repo.list()] == ["X"]
 """

--- a/src/forge/commands/generate_cmd.py
+++ b/src/forge/commands/generate_cmd.py
@@ -48,7 +48,7 @@ REPO_IFACE_TMPL = """
 from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import Iterable, Optional
-from .entities import {{Entity}}
+from .entity import {{Entity}}
 
 class I{{Entity}}Repository(ABC):
     @abstractmethod
@@ -67,9 +67,9 @@ from __future__ import annotations
 from typing import Iterable, Optional
 from sqlalchemy import select, String, Integer
 from sqlalchemy.orm import Mapped, mapped_column, Session
-from ...infra.db.base import Base
-from ...domain.{{bc}}.entities import {{Entity}}
-from ...domain.{{bc}}.repositories import I{{Entity}}Repository
+from ....infra.db.base import Base
+from ....domain.{{bc}}.{{entity_name}}.entity import {{Entity}}
+from ....domain.{{bc}}.{{entity_name}}.repository import I{{Entity}}Repository
 
 class {{Entity}}Row(Base):
     __tablename__ = "{{table}}"
@@ -100,8 +100,8 @@ class SqlAlchemy{{Entity}}Repository(I{{Entity}}Repository):
 # Service Layer Template - Business logic and use cases
 SERVICE_TMPL = """
 from __future__ import annotations
-from ...domain.{{bc}}.repositories import I{{Entity}}Repository
-from ...domain.{{bc}}.entities import {{Entity}}
+from ....domain.{{bc}}.{{entity_name}}.repository import I{{Entity}}Repository
+from ....domain.{{bc}}.{{entity_name}}.entity import {{Entity}}
 
 class {{Entity}}Service:
     def __init__(self, repo: I{{Entity}}Repository):
@@ -121,10 +121,15 @@ from flask import request
 from flask.views import MethodView
 from flask_smorest import Blueprint
 from marshmallow import Schema, fields
-from ....shared.di import Container
+from {{pkg}}.shared.di import Container
 
 # Create blueprint with OpenAPI integration
-bp = Blueprint("{{name}}", __name__, url_prefix="/{{name}}", description="{{name|title}} management endpoints")
+bp = Blueprint(
+    "{{bc|title}} - {{name|title}}", 
+    __name__, 
+    url_prefix="/{{name}}", 
+    description="{{name|title}} management endpoints"
+)
 _container: Container | None = None
 
 def init_controller(container: Container) -> None:
@@ -166,10 +171,51 @@ class {{name|title}}Collection(MethodView):
         return {"id": item.id, "name": item.name}
 """
 
+# HTTP Controller Template - Traditional Flask blueprint without OpenAPI
+CONTROLLER_BASIC_TMPL = """
+from __future__ import annotations
+from flask import Blueprint, request, jsonify
+from {{pkg}}.shared.di import Container
+
+# Create basic Flask blueprint
+bp = Blueprint(
+    "{{bc}}_{{name}}", 
+    __name__, 
+    url_prefix="/{{name}}"
+)
+_container: Container | None = None
+
+def init_controller(container: Container) -> None:
+    global _container
+    _container = container
+
+@bp.route("", methods=["GET"])
+def list_{{name}}s():
+    \"\"\"List all {{name}}s\"\"\"
+    if _container is None:
+        raise RuntimeError("Controller not initialized")
+    svc = _container.get("{{bc}}.{{name}}.service")
+    items = svc.list()
+    return jsonify({"items": [{"id": i.id, "name": i.name} for i in items]})
+
+@bp.route("", methods=["POST"])
+def create_{{name}}():
+    \"\"\"Create a new {{name}}\"\"\"
+    if _container is None:
+        raise RuntimeError("Controller not initialized")
+    data = request.get_json()
+    if not data or "name" not in data:
+        return jsonify({"error": "Missing required field: name"}), 400
+    
+    svc = _container.get("{{bc}}.{{name}}.service")
+    item = svc.create(data["name"])
+    return jsonify({"id": item.id, "name": item.name}), 201
+"""
+
 # API Registration Template - Wires controllers into the main API
 API_REG_PATCH = """
 from flask import Blueprint
-from .{{bc}}.controller import bp as {{name}}_bp, init_controller as init_{{name}}_controller
+from .{{bc}}.{{name}}_controller import bp as {{name}}_bp, init_controller as init_{{name}}_controller
 
 def register_{{name}}(api: Blueprint, container) -> None:
     init_{{name}}_controller(container)
@@ -432,7 +478,8 @@ def controller(
     Generate a Flask blueprint controller.
 
     Creates an HTTP controller with REST endpoints following
-    Flask blueprint patterns.
+    Flask blueprint patterns. Automatically detects if OpenAPI
+    is enabled and generates appropriate controller type.
 
     Args:
         bc: Bounded context name (e.g., 'catalog', 'users')
@@ -445,23 +492,66 @@ def controller(
     bc = bc.replace("-", "_")  # Normalize bounded context name
     entity_name = name.lower()  # Ensure lowercase for URL patterns
 
-    env = Environment(
-        loader=DictLoader(
-            {
-                "controller": CONTROLLER_TMPL,
-            }
-        )
-    )
+    # Detect if OpenAPI is enabled in the project
+    has_openapi = _has_openapi_enabled(pkg)
+
+    # Choose appropriate template based on OpenAPI availability
+    template_name = "controller" if has_openapi else "controller_basic"
+    templates = {
+        "controller": CONTROLLER_TMPL,
+        "controller_basic": CONTROLLER_BASIC_TMPL,
+    }
+
+    env = Environment(loader=DictLoader(templates))
 
     pkg_root = Path("src") / pkg
 
     # Ensure interface directory exists
     ensure_init_files(pkg_root, [f"interfaces/http/{bc}"])
 
-    # Generate interface layer files
-    _generate_interface_files(pkg, bc, entity_name, env)
+    # Generate interface layer files with appropriate template
+    _generate_interface_files(pkg, bc, entity_name, env, template_name)
 
-    rprint(f"[green]Controller generated:[/green] {bc}.{entity_name} (Flask blueprint)")
+    # Wire the controller into the API surface
+    _wire_api_integration(pkg, bc, entity_name)
+
+    controller_type = "OpenAPI-enabled" if has_openapi else "basic Flask"
+    rprint(f"[green]Controller generated:[/green] {bc}.{entity_name} ({controller_type} blueprint)")
+
+
+def _has_openapi_enabled(pkg: str) -> bool:
+    """
+    Check if OpenAPI is enabled in the project by looking for:
+    1. OpenAPI extension file
+    2. flask-smorest dependency in pyproject.toml
+    3. OpenAPI imports in api.py
+
+    Args:
+        pkg: Package name
+
+    Returns:
+        True if OpenAPI is enabled, False otherwise
+    """
+    # Check for OpenAPI extension file
+    openapi_ext_file = Path(f"src/{pkg}/interfaces/http/ext/openapi.py")
+    if openapi_ext_file.exists():
+        return True
+
+    # Check for flask-smorest in pyproject.toml
+    pyproject_file = Path("pyproject.toml")
+    if pyproject_file.exists():
+        content = pyproject_file.read_text(encoding="utf-8")
+        if "flask-smorest" in content:
+            return True
+
+    # Check for OpenAPI imports in api.py
+    api_file = Path(f"src/{pkg}/interfaces/http/api.py")
+    if api_file.exists():
+        content = api_file.read_text(encoding="utf-8")
+        if "from .ext.openapi import" in content or "configure_openapi" in content:
+            return True
+
+    return False
 
 
 @generate.command("resource")
@@ -525,15 +615,20 @@ def _generate_code_files(
     )
 
     pkg_root = Path("src") / pkg
+    entity_name = entity_class.lower()
 
     # Ensure all necessary directories and __init__.py files exist
     ensure_init_files(
         pkg_root,
         [
             f"domain/{bc}",
+            f"domain/{bc}/{entity_name}",
             f"app/{bc}",
+            f"app/{bc}/{entity_name}",
             f"infra/{bc}",
+            f"infra/{bc}/{entity_name}",
             f"interfaces/http/{bc}",
+            f"interfaces/http/{bc}/{entity_name}",
         ],
     )
 
@@ -553,56 +648,330 @@ def _generate_code_files(
     _generate_test_files(pkg, bc, entity_class, entity_name)
 
 
+def _append_to_entities_file(entities_file: Path, entity_class: str, env: Environment) -> None:
+    """Append entity to entities.py file or create it if it doesn't exist."""
+    if not entities_file.exists():
+        # Create new file with header
+        content = f"""from __future__ import annotations
+from dataclasses import dataclass
+
+{env.get_template("entity").render(Entity=entity_class).strip()}
+"""
+    else:
+        # Read existing content and append new entity
+        existing_content = entities_file.read_text(encoding="utf-8")
+        if f"class {entity_class}:" not in existing_content:
+            entity_code = env.get_template("entity").render(Entity=entity_class).strip()
+            # Remove the imports and dataclass import from the template
+            entity_lines = entity_code.split("\n")
+            entity_only = []
+            skip_until_dataclass = True
+            for line in entity_lines:
+                if line.strip().startswith("@dataclass"):
+                    skip_until_dataclass = False
+                if not skip_until_dataclass:
+                    entity_only.append(line)
+
+            content = existing_content.rstrip() + "\n\n" + "\n".join(entity_only) + "\n"
+        else:
+            content = existing_content
+
+    entities_file.write_text(content, encoding="utf-8")
+
+
+def _append_to_repositories_file(repos_file: Path, entity_class: str, env: Environment) -> None:
+    """Append repository interface to repositories.py file or create it if it doesn't exist."""
+    if not repos_file.exists():
+        # Create new file
+        content = env.get_template("repo_iface").render(Entity=entity_class)
+    else:
+        # Read existing content and append new repository interface
+        existing_content = repos_file.read_text(encoding="utf-8")
+        if f"class I{entity_class}Repository(" not in existing_content:
+            repo_code = env.get_template("repo_iface").render(Entity=entity_class)
+            # Extract just the class definition from the template
+            repo_lines = repo_code.split("\n")
+            class_start = None
+            for i, line in enumerate(repo_lines):
+                if line.startswith(f"class I{entity_class}Repository("):
+                    class_start = i
+                    break
+
+            if class_start is not None:
+                class_lines = repo_lines[class_start:]
+                # Add import for the entity if not present
+                if f"from .entities import {entity_class}" not in existing_content:
+                    # Find the last import line and add after it
+                    lines = existing_content.split("\n")
+                    last_import_idx = 0
+                    for i, line in enumerate(lines):
+                        if line.startswith("from .entities import"):
+                            last_import_idx = i
+
+                    # Update the import line to include the new entity
+                    import_line = lines[last_import_idx]
+                    if import_line.endswith(")"):
+                        # Multi-line import
+                        lines[last_import_idx] = import_line[:-1] + f", {entity_class})"
+                    else:
+                        # Single line import
+                        lines[last_import_idx] = import_line + f", {entity_class}"
+
+                    existing_content = "\n".join(lines)
+
+                content = existing_content.rstrip() + "\n\n" + "\n".join(class_lines) + "\n"
+            else:
+                content = existing_content
+        else:
+            content = existing_content
+
+    repos_file.write_text(content, encoding="utf-8")
+
+
+def _append_to_sqlalchemy_repo_file(
+    repo_file: Path, entity_class: str, table_name: str, bc: str, env: Environment
+) -> None:
+    """Append SQLAlchemy repository to repo_sqlalchemy.py file or create it if it doesn't exist."""
+    if not repo_file.exists():
+        # Create new file
+        content = env.get_template("repo_sqla").render(Entity=entity_class, bc=bc, table=table_name)
+    else:
+        # Read existing content and append new repository implementation
+        existing_content = repo_file.read_text(encoding="utf-8")
+        if f"class SqlAlchemy{entity_class}Repository(" not in existing_content:
+            repo_code = env.get_template("repo_sqla").render(
+                Entity=entity_class, bc=bc, table=table_name
+            )
+
+            # Extract the class definitions from the template (both Row and Repository classes)
+            repo_lines = repo_code.split("\n")
+
+            # Find the start of the Row class and Repository class
+            row_class_start = None
+            repo_class_start = None
+
+            for i, line in enumerate(repo_lines):
+                if line.startswith(f"class {entity_class}Row("):
+                    row_class_start = i
+                elif line.startswith(f"class SqlAlchemy{entity_class}Repository("):
+                    repo_class_start = i
+
+            if row_class_start is not None and repo_class_start is not None:
+                # Get the row class and repository class code
+                new_classes = repo_lines[row_class_start:]
+
+                # Add import for the entity if not present
+                if f"from ...domain.{bc}.entities import {entity_class}" not in existing_content:
+                    # Find the last domain import and add after it
+                    lines = existing_content.split("\n")
+                    last_domain_import_idx = 0
+                    for i, line in enumerate(lines):
+                        if "from ...domain." in line and ".entities import" in line:
+                            last_domain_import_idx = i
+
+                    # Update the import line to include the new entity
+                    import_line = lines[last_domain_import_idx]
+                    if import_line.endswith(")"):
+                        # Multi-line import - shouldn't happen with current template
+                        lines[last_domain_import_idx] = import_line[:-1] + f", {entity_class})"
+                    else:
+                        # Single line import
+                        entity_name = import_line.split(" import ")[1]
+                        lines[last_domain_import_idx] = import_line.replace(
+                            entity_name, f"{entity_name}, {entity_class}"
+                        )
+
+                    existing_content = "\n".join(lines)
+
+                # Add repository interface import if not present
+                if (
+                    f"from ...domain.{bc}.repositories import I{entity_class}Repository"
+                    not in existing_content
+                ):
+                    lines = existing_content.split("\n")
+                    last_repo_import_idx = 0
+                    for i, line in enumerate(lines):
+                        if "from ...domain." in line and ".repositories import" in line:
+                            last_repo_import_idx = i
+
+                    # Update the repository import line
+                    import_line = lines[last_repo_import_idx]
+                    if import_line.endswith(")"):
+                        lines[last_repo_import_idx] = (
+                            import_line[:-1] + f", I{entity_class}Repository)"
+                        )
+                    else:
+                        repo_name = import_line.split(" import ")[1]
+                        lines[last_repo_import_idx] = import_line.replace(
+                            repo_name, f"{repo_name}, I{entity_class}Repository"
+                        )
+
+                    existing_content = "\n".join(lines)
+
+                content = existing_content.rstrip() + "\n\n\n" + "\n".join(new_classes) + "\n"
+            else:
+                content = existing_content
+        else:
+            content = existing_content
+
+    repo_file.write_text(content, encoding="utf-8")
+
+
+def _append_to_services_file(
+    services_file: Path, entity_class: str, bc: str, env: Environment
+) -> None:
+    """Append service to services.py file or create it if it doesn't exist."""
+    if not services_file.exists():
+        # Create new file
+        content = env.get_template("service").render(Entity=entity_class, bc=bc)
+    else:
+        # Read existing content and append new service
+        existing_content = services_file.read_text(encoding="utf-8")
+        if f"class {entity_class}Service:" not in existing_content:
+            service_code = env.get_template("service").render(Entity=entity_class, bc=bc)
+
+            # Extract the class definition from the template
+            service_lines = service_code.split("\n")
+            class_start = None
+            for i, line in enumerate(service_lines):
+                if line.startswith(f"class {entity_class}Service:"):
+                    class_start = i
+                    break
+
+            if class_start is not None:
+                class_lines = service_lines[class_start:]
+
+                # Add imports if not present
+                if (
+                    f"from ...domain.{bc}.repositories import I{entity_class}Repository"
+                    not in existing_content
+                ):
+                    lines = existing_content.split("\n")
+                    last_repo_import_idx = 0
+                    for i, line in enumerate(lines):
+                        if "from ...domain." in line and ".repositories import" in line:
+                            last_repo_import_idx = i
+
+                    # Update the repository import line
+                    import_line = lines[last_repo_import_idx]
+                    repo_name = import_line.split(" import ")[1]
+                    lines[last_repo_import_idx] = import_line.replace(
+                        repo_name, f"{repo_name}, I{entity_class}Repository"
+                    )
+                    existing_content = "\n".join(lines)
+
+                if f"from ...domain.{bc}.entities import {entity_class}" not in existing_content:
+                    lines = existing_content.split("\n")
+                    last_entity_import_idx = 0
+                    for i, line in enumerate(lines):
+                        if "from ...domain." in line and ".entities import" in line:
+                            last_entity_import_idx = i
+
+                    # Update the entity import line
+                    import_line = lines[last_entity_import_idx]
+                    entity_name = import_line.split(" import ")[1]
+                    lines[last_entity_import_idx] = import_line.replace(
+                        entity_name, f"{entity_name}, {entity_class}"
+                    )
+                    existing_content = "\n".join(lines)
+
+                content = existing_content.rstrip() + "\n\n" + "\n".join(class_lines) + "\n"
+            else:
+                content = existing_content
+        else:
+            content = existing_content
+
+    services_file.write_text(content, encoding="utf-8")
+
+
 def _generate_domain_files(pkg: str, bc: str, entity_class: str, env: Environment) -> None:
     """Generate domain layer files (entities and repository interfaces)."""
-    domain_path = Path(f"src/{pkg}/domain/{bc}")
-    domain_path.mkdir(parents=True, exist_ok=True)
+    entity_name = entity_class.lower()
 
-    # Generate entity
-    (domain_path / "entities.py").write_text(
-        env.get_template("entity").render(Entity=entity_class), encoding="utf-8"
-    )
+    # Create entity-specific subdirectory
+    entity_domain_path = Path(f"src/{pkg}/domain/{bc}/{entity_name}")
+    entity_domain_path.mkdir(parents=True, exist_ok=True)
 
-    # Generate repository interface
-    (domain_path / "repositories.py").write_text(
+    # Generate entity in entity.py
+    entity_file = entity_domain_path / "entity.py"
+    entity_file.write_text(env.get_template("entity").render(Entity=entity_class), encoding="utf-8")
+
+    # Generate repository interface in repository.py
+    repo_file = entity_domain_path / "repository.py"
+    repo_file.write_text(
         env.get_template("repo_iface").render(Entity=entity_class), encoding="utf-8"
     )
+
+    # Create __init__.py for the entity subdirectory
+    init_file = entity_domain_path / "__init__.py"
+    init_file.write_text("", encoding="utf-8")
 
 
 def _generate_infrastructure_files(
     pkg: str, bc: str, entity_class: str, table_name: str, env: Environment
 ) -> None:
     """Generate infrastructure layer files (repository implementations)."""
-    infra_path = Path(f"src/{pkg}/infra/{bc}")
-    infra_path.mkdir(parents=True, exist_ok=True)
+    entity_name = entity_class.lower()
 
-    # Generate SQLAlchemy repository implementation
-    (infra_path / "repo_sqlalchemy.py").write_text(
-        env.get_template("repo_sqla").render(Entity=entity_class, bc=bc, table=table_name),
+    # Create entity-specific subdirectory
+    entity_infra_path = Path(f"src/{pkg}/infra/{bc}/{entity_name}")
+    entity_infra_path.mkdir(parents=True, exist_ok=True)
+
+    # Generate SQLAlchemy repository implementation in repo_sqlalchemy.py
+    repo_file = entity_infra_path / "repo_sqlalchemy.py"
+    repo_file.write_text(
+        env.get_template("repo_sqla").render(
+            Entity=entity_class, bc=bc, table=table_name, entity_name=entity_name
+        ),
         encoding="utf-8",
     )
+
+    # Create __init__.py for the entity subdirectory
+    init_file = entity_infra_path / "__init__.py"
+    init_file.write_text("", encoding="utf-8")
 
 
 def _generate_application_files(pkg: str, bc: str, entity_class: str, env: Environment) -> None:
     """Generate application layer files (services)."""
-    app_path = Path(f"src/{pkg}/app/{bc}")
-    app_path.mkdir(parents=True, exist_ok=True)
+    entity_name = entity_class.lower()
 
-    # Generate service
-    (app_path / "services.py").write_text(
-        env.get_template("service").render(Entity=entity_class, bc=bc), encoding="utf-8"
+    # Create entity-specific subdirectory
+    entity_app_path = Path(f"src/{pkg}/app/{bc}/{entity_name}")
+    entity_app_path.mkdir(parents=True, exist_ok=True)
+
+    # Generate service in service.py
+    services_file = entity_app_path / "service.py"
+    services_file.write_text(
+        env.get_template("service").render(Entity=entity_class, bc=bc, entity_name=entity_name),
+        encoding="utf-8",
     )
 
+    # Create __init__.py for the entity subdirectory
+    init_file = entity_app_path / "__init__.py"
+    init_file.write_text("", encoding="utf-8")
 
-def _generate_interface_files(pkg: str, bc: str, entity_name: str, env: Environment) -> None:
+
+def _generate_interface_files(
+    pkg: str, bc: str, entity_name: str, env: Environment, template_name: str = "controller"
+) -> None:
     """Generate interface layer files (HTTP controllers)."""
-    interface_path = Path(f"src/{pkg}/interfaces/http/{bc}")
-    interface_path.mkdir(parents=True, exist_ok=True)
+    # Create entity-specific subdirectory
+    entity_interface_path = Path(f"src/{pkg}/interfaces/http/{bc}/{entity_name}")
+    entity_interface_path.mkdir(parents=True, exist_ok=True)
 
-    # Generate HTTP controller
-    (interface_path / "controller.py").write_text(
-        env.get_template("controller").render(bc=bc, name=entity_name), encoding="utf-8"
+    # Generate HTTP controller in controller.py using specified template
+    controller_file = entity_interface_path / "controller.py"
+    controller_file.write_text(
+        env.get_template(template_name).render(pkg=pkg, bc=bc, name=entity_name), encoding="utf-8"
     )
+
+    # Create __init__.py for the entity subdirectory
+    init_file = entity_interface_path / "__init__.py"
+    init_content = """from .controller import bp, init_controller
+
+__all__ = ["bp", "init_controller"]
+"""
+    init_file.write_text(init_content, encoding="utf-8")
 
 
 def _wire_api_integration(pkg: str, bc: str, entity_name: str) -> None:
@@ -610,36 +979,53 @@ def _wire_api_integration(pkg: str, bc: str, entity_name: str) -> None:
     api_file = Path(f"src/{pkg}/interfaces/http/api.py")
     api_content = api_file.read_text(encoding="utf-8")
 
-    # Define the lines to be inserted
-    import_line = f"from .{bc}.controller import bp as {entity_name}_bp, init_controller as init_{entity_name}_controller"
-    register_line = f"    api.register_blueprint({entity_name}_bp)"
-    init_line = f"    init_{entity_name}_controller(container)"
+    # Define the lines to be inserted with subdirectory structure
+    import_line = f"from .{bc}.{entity_name}.controller import bp as {bc}_{entity_name}_bp, init_controller as init_{bc}_{entity_name}_controller"
+    register_line = f"    api.register_blueprint({bc}_{entity_name}_bp)"
+    init_line = f"    init_{bc}_{entity_name}_controller(container)"
 
-    # Check if OpenAPI is available and add special handling for flask-smorest
+    # Check if OpenAPI is available
     has_openapi = "from .ext.openapi import configure_openapi" in api_content
 
     if has_openapi:
-        # For OpenAPI integration, we need to register with the smorest API instance
+        # For OpenAPI integration, ensure we have the necessary imports and wiring function
         openapi_import = "from .ext.openapi import get_api_instance"
-        openapi_register_logic = f"""    # Register with OpenAPI if available
+
+        # Add the _wire_api_integration function if it doesn't exist
+        wire_function = f"""
+def _wire_api_integration():
+    \"\"\"Wire OpenAPI integration after it's been configured.\"\"\"
     openapi_api = get_api_instance()
-    if openapi_api and hasattr({entity_name}_bp, 'doc'):
-        # This is a flask-smorest blueprint, register with API
-        openapi_api.register_blueprint({entity_name}_bp)
-    else:
-        # Fallback to regular Flask blueprint registration
-        api.register_blueprint({entity_name}_bp)"""
+    if openapi_api:
+        # Register OpenAPI-capable controllers with the API instance
+        if hasattr({bc}_{entity_name}_bp, 'doc'):
+            try:
+                openapi_api.register_blueprint({bc}_{entity_name}_bp)
+            except Exception:
+                pass  # Already registered or error"""
 
-        # Insert OpenAPI import
-        api_content = _insert_line_once(
-            api_content,
-            openapi_import,
-            "# [forge:auto-imports]",
-            r"(?ms)(^from\s+[^\n]+$|^import\s+[^\n]+$)(?:\n(?:from\s+[^\n]+$|import\s+[^\n]+$))*",
-        )
+        # Insert OpenAPI import if not present
+        if openapi_import not in api_content:
+            api_content = _insert_line_once(
+                api_content,
+                openapi_import,
+                "# [forge:auto-imports]",
+                r"(?ms)(^from\s+[^\n]+$|^import\s+[^\n]+$)(?:\n(?:from\s+[^\n]+$|import\s+[^\n]+$))*",
+            )
 
-        # Replace simple register line with OpenAPI-aware logic
-        register_line = openapi_register_logic
+        # Add the wire function if it doesn't exist
+        if "_wire_api_integration" not in api_content:
+            # Insert before register_http function
+            pattern = r"(def register_http)"
+            replacement = wire_function + "\n\n\\1"
+            api_content = re.sub(pattern, replacement, api_content)
+
+        # Update the register_http function to call _wire_api_integration
+        if "_wire_api_integration()" not in api_content:
+            # Insert the call after configure_openapi
+            pattern = r"(configure_openapi\(app\))"
+            replacement = "\\1\n    \n    # Wire OpenAPI integration after configuring it\n    _wire_api_integration()"
+            api_content = re.sub(pattern, replacement, api_content)
 
     # Insert import, register, and init lines
     api_content = _insert_line_once(
@@ -665,26 +1051,15 @@ def _wire_api_integration(pkg: str, bc: str, entity_name: str) -> None:
 
     api_file.write_text(api_content, encoding="utf-8")
 
-    api_content = _insert_line_once(
-        api_content,
-        init_line,
-        "    # [forge:auto-init]",
-        r"(?ms)def\s+register_http\([^\)]*\):\s*\n(.*?)\n\s*app\.register_blueprint\(api_bp\)",
-    )
-
-    api_file.write_text(api_content, encoding="utf-8")
-
 
 def _setup_dependency_injection(pkg: str, bc: str, entity_class: str, entity_name: str) -> None:
     """Setup dependency injection wiring for the new resource."""
     wiring_file = Path(f"src/{pkg}/shared/di_wiring.py")
     wiring_content = wiring_file.read_text(encoding="utf-8")
 
-    # Add imports for repository and service
-    import_repo = (
-        f"from {pkg}.infra.{bc}.repo_sqlalchemy import SqlAlchemy{entity_class}Repository\n"
-    )
-    import_service = f"from {pkg}.app.{bc}.services import {entity_class}Service\n"
+    # Add imports for repository and service from subdirectories
+    import_repo = f"from {pkg}.infra.{bc}.{entity_name}.repo_sqlalchemy import SqlAlchemy{entity_class}Repository\n"
+    import_service = f"from {pkg}.app.{bc}.{entity_name}.service import {entity_class}Service\n"
 
     wiring_content = _insert_after_line(
         wiring_content,
@@ -710,15 +1085,66 @@ def _setup_dependency_injection(pkg: str, bc: str, entity_class: str, entity_nam
         wiring_content += registration_func
 
     # Add call to registration function in register_features
-    call_line = f"    register_{entity_name}(container)\n"
+    call_line = f"    register_{entity_name}(container)"
     if "def register_features(" in wiring_content and call_line not in wiring_content:
-        wiring_content = re.sub(
-            r"(def\s+register_features\(.*?\):\s*\n)",
-            r"\1" + call_line,
-            wiring_content,
-            count=1,
-            flags=re.DOTALL,
-        )
+        # Find the register_features function and add the call
+        lines = wiring_content.split("\n")
+        new_lines = []
+        in_register_features = False
+        added_call = False
+
+        for i, line in enumerate(lines):
+            new_lines.append(line)
+
+            # Detect start of register_features function
+            if "def register_features(container: Container) -> None:" in line:
+                in_register_features = True
+                continue
+
+            # If we're in register_features and find the end of function
+            if (
+                in_register_features
+                and line.strip() == ""
+                and i + 1 < len(lines)
+                and lines[i + 1].strip()
+                and not lines[i + 1].startswith("    ")
+            ):
+                # End of function, add call before this line if not added yet
+                if not added_call:
+                    # Insert before the empty line
+                    new_lines.insert(-1, call_line)
+                    added_call = True
+                in_register_features = False
+                continue
+
+            # If we're in register_features and find a pass statement, replace it
+            if in_register_features and line.strip() == "pass":
+                new_lines[-1] = call_line  # Replace the pass line
+                added_call = True
+                continue
+
+            # If we're in register_features and find an existing register call, add after all calls
+            if (
+                in_register_features
+                and "register_" in line
+                and "(container)" in line
+                and not added_call
+            ):
+                # Look ahead to see if there are more register calls
+                has_more_calls = False
+                for j in range(i + 1, len(lines)):
+                    if lines[j].strip() == "":
+                        break
+                    if "register_" in lines[j] and "(container)" in lines[j]:
+                        has_more_calls = True
+                        break
+
+                # If no more calls after this one, add our call
+                if not has_more_calls:
+                    new_lines.append(call_line)
+                    added_call = True
+
+        wiring_content = "\n".join(new_lines)
 
     wiring_file.write_text(wiring_content, encoding="utf-8")
 

--- a/src/forge/commands/plugin_cmd.py
+++ b/src/forge/commands/plugin_cmd.py
@@ -57,12 +57,14 @@ def openapi():
     else:
         rprint("[yellow]API file already configured")
 
+    # Register existing controllers with OpenAPI
+    _register_existing_controllers(root, pkg)
+
     rprint("[green]✓ OpenAPI installed.")
     rprint("[blue]Available routes:")
-    rprint("[blue]  • Swagger UI: /docs-[unique-id]/swagger-ui")
-    rprint("[blue]  • ReDoc: /docs-[unique-id]/redoc")
-    rprint("[blue]  • OpenAPI spec: /docs-[unique-id]/openapi.json")
-    rprint("[yellow]Note: [unique-id] will be a generated 8-character identifier")
+    rprint("[blue]  • Swagger UI: /docs/swagger-ui")
+    rprint("[blue]  • ReDoc: /docs/redoc")
+    rprint("[blue]  • OpenAPI spec: /docs/openapi.json")
 
 
 def _update_pyproject_dependencies(pyproject_path: Path) -> bool:
@@ -193,12 +195,12 @@ def _add_api_init_call(lines: list[str]) -> bool:
 _OPENAPI_EXT = """
 from __future__ import annotations
 from flask_smorest import Api
-import uuid
+from flask import Flask
 
 # Global API instance para que los blueprints puedan registrarse
 openapi_api = None
 
-def configure_openapi(app):
+def configure_openapi(app: Flask):
     \"\"\"Configure OpenAPI/Swagger documentation.\"\"\"
     global openapi_api
     
@@ -219,9 +221,170 @@ def configure_openapi(app):
     openapi_api = Api()
     openapi_api.init_app(app)
     
+    # Register any existing blueprints that were created with flask-smorest
+    _register_existing_blueprints(app)
+    
     return openapi_api
 
 def get_api_instance():
     \"\"\"Get the global API instance for blueprint registration.\"\"\"
     return openapi_api
+
+def _register_existing_blueprints(app: Flask):
+    \"\"\"Register existing controller blueprints with the API instance.\"\"\"
+    if not openapi_api:
+        return
+        
+    # Look for blueprints that were created with flask-smorest
+    for blueprint in app.blueprints.values():
+        # Check if this is a flask-smorest blueprint by looking for specific attributes
+        if hasattr(blueprint, '_spec') or 'swagger-ui' in str(blueprint.url_prefix or ''):
+            continue  # Skip already registered or system blueprints
+            
+        # Register the blueprint with the API if it looks like a controller blueprint
+        if blueprint.url_prefix and blueprint.url_prefix.startswith('/'):
+            try:
+                openapi_api.register_blueprint(blueprint)
+            except Exception:
+                # Blueprint might already be registered or incompatible
+                pass
 """
+
+
+def _register_existing_controllers(root: Path, pkg: str) -> None:
+    """Register existing controller blueprints with OpenAPI."""
+    api_file = root / f"src/{pkg}/interfaces/http/api.py"
+    if not api_file.exists():
+        return
+
+    # Find all existing controller files
+    controllers_path = root / f"src/{pkg}/interfaces/http"
+    controller_files = list(controllers_path.glob("**/controller.py"))
+
+    if not controller_files:
+        rprint("[yellow]No existing controllers found")
+        return
+
+    rprint(f"[blue]Found {len(controller_files)} existing controllers")
+
+    # Update api.py to register existing controllers with OpenAPI
+    content = api_file.read_text(encoding="utf-8")
+    lines = content.split("\n")
+
+    # Extract controller info
+    controllers: list[tuple[str, str]] = []
+    for controller_file in controller_files:
+        rel_path = controller_file.relative_to(controllers_path)
+        path_parts = rel_path.parts[:-1]  # Remove 'controller.py'
+
+        if len(path_parts) >= 2:
+            bc, entity = path_parts[0], path_parts[1]
+            controllers.append((bc, entity))
+
+    if not controllers:
+        rprint("[yellow]No valid controllers found")
+        return
+
+    # Update register_http function to use OpenAPI
+    modified = _update_register_http_for_openapi(lines, controllers)
+
+    if modified:
+        api_file.write_text("\n".join(lines), encoding="utf-8")
+        rprint("[green]✓ Updated API file with OpenAPI registrations")
+    else:
+        rprint("[yellow]API file already configured for OpenAPI")
+
+
+def _update_register_http_for_openapi(lines: list[str], controllers: list[tuple[str, str]]) -> bool:
+    """Update register_http function to register blueprints with OpenAPI. Returns True if modified."""
+    register_http_idx = _find_register_http_function(lines)
+    if register_http_idx is None:
+        return False
+
+    openapi_call_idx = _find_and_update_openapi_call(lines, register_http_idx)
+    if openapi_call_idx is None:
+        return False
+
+    existing_registrations = _get_existing_openapi_registrations(lines, openapi_call_idx)
+    if existing_registrations:
+        return False
+
+    insert_idx = _find_insertion_point(lines, openapi_call_idx)
+    return _add_openapi_registrations(lines, insert_idx, controllers)
+
+
+def _find_register_http_function(lines: list[str]) -> int | None:
+    """Find the register_http function. Returns its line index or None."""
+    for i, line in enumerate(lines):
+        if "def register_http(app" in line:
+            return i
+    return None
+
+
+def _find_and_update_openapi_call(lines: list[str], start_idx: int) -> int | None:
+    """Find and update configure_openapi call. Returns its line index or None."""
+    for j in range(start_idx + 1, len(lines)):
+        if "configure_openapi(app)" in lines[j]:
+            if not lines[j].strip().startswith("api ="):
+                lines[j] = lines[j].replace(
+                    "configure_openapi(app)", "api = configure_openapi(app)"
+                )
+            return j
+        elif _is_end_of_function_section(lines[j]):
+            break
+    return None
+
+
+def _get_existing_openapi_registrations(lines: list[str], start_idx: int) -> list[str]:
+    """Get existing OpenAPI registrations after the given index."""
+    registrations: list[str] = []
+    for j in range(start_idx + 1, len(lines)):
+        if "api.register_blueprint(" in lines[j]:
+            registrations.append(lines[j])
+        elif _is_end_of_function_section(lines[j]):
+            break
+    return registrations
+
+
+def _find_insertion_point(lines: list[str], openapi_call_idx: int) -> int:
+    """Find the best insertion point for OpenAPI registrations."""
+    insert_idx = openapi_call_idx + 1
+
+    for j in range(openapi_call_idx + 1, len(lines)):
+        if "init_" in lines[j] and "_controller(container)" in lines[j]:
+            insert_idx = j + 1
+        elif "app.register_blueprint(api_bp)" in lines[j]:
+            return j
+        elif _is_end_of_function_section(lines[j]):
+            break
+
+    return insert_idx
+
+
+def _add_openapi_registrations(
+    lines: list[str], insert_idx: int, controllers: list[tuple[str, str]]
+) -> bool:
+    """Add OpenAPI registrations for controllers. Returns True if modified."""
+    lines.insert(insert_idx, "")
+    lines.insert(insert_idx + 1, "    # Register existing controllers with OpenAPI")
+    insert_idx += 2
+
+    for bc, entity in controllers:
+        bp_name = f"{bc}_{entity}_bp"
+        reg_line = f"    if hasattr({bp_name}, 'doc'):"
+        conditional_reg = f"        api.register_blueprint({bp_name})"
+
+        if reg_line not in lines:
+            lines.insert(insert_idx, reg_line)
+            lines.insert(insert_idx + 1, conditional_reg)
+            insert_idx += 2
+
+    lines.insert(insert_idx, "")
+    return True
+
+
+def _is_end_of_function_section(line: str) -> bool:
+    """Check if line indicates end of current function section."""
+    return bool(
+        line.strip() and not line.startswith("    ") and not line.startswith("#") and line != ""
+    )

--- a/src/forge/commands/plugin_cmd.py
+++ b/src/forge/commands/plugin_cmd.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+import re
+from pathlib import Path
+import typer
+from rich import print as rprint
+
+plugin = typer.Typer(help="Optional features")
+
+# Constants
+OPENAPI_IMPORT = "from .ext.openapi import configure_openapi"
+API_INIT_CALL = "configure_openapi(app)"
+FORGE_AUTO_IMPORTS = "# [forge:auto-imports]"
+FORGE_AUTO_INIT = "# [forge:auto-init]"
+
+
+def _detect_pkg() -> str:
+    for p in Path("src").glob("*/main.py"):
+        return p.parent.name
+    raise SystemExit("pkg not found")
+
+
+@plugin.command("openapi")
+def openapi():
+    """Install OpenAPI support with proper validation and error handling."""
+    root = Path(".")
+    if not (root / "pyproject.toml").exists():
+        raise SystemExit("Run from project root")
+
+    pkg = _detect_pkg()
+
+    # Validate that api.py exists
+    api_file = root / f"src/{pkg}/interfaces/http/api.py"
+    if not api_file.exists():
+        raise SystemExit(f"API file not found: {api_file}")
+
+    # Create ext/openapi.py
+    ext_dir = root / f"src/{pkg}/interfaces/http/ext"
+    ext_dir.mkdir(parents=True, exist_ok=True)
+    openapi_file = ext_dir / "openapi.py"
+
+    if openapi_file.exists():
+        rprint("[yellow]OpenAPI extension already exists, skipping creation")
+    else:
+        openapi_file.write_text(_OPENAPI_EXT, encoding="utf-8")
+        rprint("[green]Created OpenAPI extension file")
+
+    # Update dependencies
+    if _update_pyproject_dependencies(root / "pyproject.toml"):
+        rprint("[green]Updated pyproject.toml dependencies")
+    else:
+        rprint("[yellow]Dependencies already up to date")
+
+    # Update API file
+    rprint(f"[blue]Updating API file: {api_file}")
+    if _update_api_file(api_file):
+        rprint("[green]Updated API file with OpenAPI integration")
+    else:
+        rprint("[yellow]API file already configured")
+
+    rprint("[green]✓ OpenAPI installed.")
+    rprint("[blue]Available routes:")
+    rprint("[blue]  • Swagger UI: /docs-[unique-id]/swagger-ui")
+    rprint("[blue]  • ReDoc: /docs-[unique-id]/redoc")
+    rprint("[blue]  • OpenAPI spec: /docs-[unique-id]/openapi.json")
+    rprint("[yellow]Note: [unique-id] will be a generated 8-character identifier")
+
+
+def _update_pyproject_dependencies(pyproject_path: Path) -> bool:
+    """Update pyproject.toml dependencies. Returns True if changes were made."""
+    content = pyproject_path.read_text(encoding="utf-8")
+    required_deps = ["flask-smorest", "marshmallow"]
+
+    # Check if deps exist and track missing ones
+    missing_deps: list[str] = []
+    for dep in required_deps:
+        # Look for the dependency with proper word boundaries
+        if not re.search(rf'["\']({dep})["><=~!\s]', content):
+            missing_deps.append(dep)
+
+    if not missing_deps:
+        return False
+
+    # Add missing dependencies using simple string replacement
+    lines = content.split("\n")
+    for i, line in enumerate(lines):
+        if "dependencies = [" in line:
+            # Handle single-line dependencies array
+            if line.strip().endswith("]"):
+                closing_bracket = line.rfind("]")
+                deps_to_insert = "".join(f'"{dep}>=0",' for dep in missing_deps)
+                lines[i] = line[:closing_bracket] + deps_to_insert + line[closing_bracket:]
+            else:
+                # Multi-line: add after the opening bracket
+                for j, dep in enumerate(missing_deps):
+                    lines.insert(i + 1 + j, f'    "{dep}>=0",')
+            break
+
+    pyproject_path.write_text("\n".join(lines), encoding="utf-8")
+    return True
+
+
+def _update_api_file(api_file: Path) -> bool:
+    """Update api.py file to include OpenAPI. Returns True if changes were made."""
+    content = api_file.read_text(encoding="utf-8")
+    lines = content.split("\n")
+    modified = False
+
+    rprint("[blue]Checking if OpenAPI import exists...")
+    if OPENAPI_IMPORT not in content:
+        rprint("[blue]Adding OpenAPI import...")
+        if _add_openapi_import(lines):
+            modified = True
+            rprint("[green]✓ Added OpenAPI import")
+    else:
+        rprint("[yellow]OpenAPI import already exists")
+
+    rprint("[blue]Checking if configure_openapi(app) exists...")
+    if API_INIT_CALL not in content:
+        rprint("[blue]Adding configure_openapi(app) call...")
+        if _add_api_init_call(lines):
+            modified = True
+            rprint("[green]✓ Added configure_openapi(app) call")
+    else:
+        rprint("[yellow]configure_openapi(app) already exists")
+
+    if modified:
+        api_file.write_text("\n".join(lines), encoding="utf-8")
+        rprint("[green]✓ API file updated successfully")
+
+    return modified
+
+
+def _add_openapi_import(lines: list[str]) -> bool:
+    """Add OpenAPI import to the lines. Returns True if modified."""
+    # Check if already exists
+    if any(OPENAPI_IMPORT in line for line in lines):
+        return False
+
+    # Try forge marker first
+    for i, line in enumerate(lines):
+        if FORGE_AUTO_IMPORTS in line:
+            lines[i] = f"{OPENAPI_IMPORT}\n{FORGE_AUTO_IMPORTS}"
+            return True
+
+    # Find insertion point after imports or at beginning
+    insert_idx = _find_import_insertion_point(lines)
+    lines.insert(insert_idx, OPENAPI_IMPORT)
+    return True
+
+
+def _find_import_insertion_point(lines: list[str]) -> int:
+    """Find the best place to insert an import statement."""
+    # Find last import line
+    last_import_idx = -1
+    for i, line in enumerate(lines):
+        if line.strip() and ("import " in line or "from " in line) and not line.startswith("#"):
+            last_import_idx = i
+
+    if last_import_idx >= 0:
+        return last_import_idx + 1
+
+    # If no imports found, add after initial comments
+    for i, line in enumerate(lines):
+        if line.strip() and not line.startswith("#"):
+            return i
+
+    # Fallback: beginning of file
+    return 0
+
+
+def _add_api_init_call(lines: list[str]) -> bool:
+    """Add configure_openapi(app) call. Returns True if modified."""
+    # Check if already exists
+    if any(API_INIT_CALL in line for line in lines):
+        return False
+
+    for i, line in enumerate(lines):
+        if "def register_http(app" in line:
+            # Look for forge marker
+            for j in range(i + 1, len(lines)):
+                if FORGE_AUTO_INIT in lines[j]:
+                    # Insert before the existing content, after the marker
+                    lines.insert(j + 1, f"    {API_INIT_CALL}")
+                    return True
+                elif lines[j].strip() and not lines[j].startswith("    #"):
+                    # Insert before first non-comment line in function
+                    lines.insert(j, f"    {API_INIT_CALL}")
+                    return True
+            break
+    return False
+
+
+_OPENAPI_EXT = """
+from __future__ import annotations
+from flask_smorest import Api
+import uuid
+
+# Global API instance para que los blueprints puedan registrarse
+openapi_api = None
+
+def configure_openapi(app):
+    \"\"\"Configure OpenAPI/Swagger documentation.\"\"\"
+    global openapi_api
+    
+    # Configure app settings for flask-smorest
+    app.config.update({
+        'API_TITLE': 'Flask API',
+        'API_VERSION': 'v1',
+        'OPENAPI_VERSION': '3.0.3',
+        'OPENAPI_URL_PREFIX': f'/docs',
+        'OPENAPI_SWAGGER_UI_PATH': '/swagger-ui',
+        'OPENAPI_SWAGGER_UI_URL': 'https://cdn.jsdelivr.net/npm/swagger-ui-dist/',
+        'OPENAPI_REDOC_PATH': '/redoc',
+        'OPENAPI_REDOC_URL': 'https://cdn.jsdelivr.net/npm/redoc@2.0.0/bundles/redoc.standalone.js',
+        'OPENAPI_JSON_PATH': '/openapi.json'
+    })
+    
+    # Create and initialize API instance
+    openapi_api = Api()
+    openapi_api.init_app(app)
+    
+    return openapi_api
+
+def get_api_instance():
+    \"\"\"Get the global API instance for blueprint registration.\"\"\"
+    return openapi_api
+"""

--- a/src/forge/commands/plugin_cmd.py
+++ b/src/forge/commands/plugin_cmd.py
@@ -197,7 +197,7 @@ from __future__ import annotations
 from flask_smorest import Api
 from flask import Flask
 
-# Global API instance para que los blueprints puedan registrarse
+# Global API instance so blueprints can register themselves
 openapi_api = None
 
 def configure_openapi(app: Flask):

--- a/src/forge/commands/plugin_cmd.py
+++ b/src/forge/commands/plugin_cmd.py
@@ -76,7 +76,7 @@ def _update_pyproject_dependencies(pyproject_path: Path) -> bool:
     missing_deps: list[str] = []
     for dep in required_deps:
         # Look for the dependency with proper word boundaries
-        if not re.search(rf'["\']({dep})["><=~!\s]', content):
+        if not re.search(rf'["\']({dep})[]"><=~!\s]', content):
             missing_deps.append(dep)
 
     if not missing_deps:


### PR DESCRIPTION
This pull request introduces a new plugin system to the CLI, specifically adding an `openapi` command that automates the installation and integration of OpenAPI/Swagger documentation into Flask projects. The main changes include the addition of a new CLI command, supporting code for OpenAPI integration, and updates to dependencies.

**New Plugin System and OpenAPI Integration:**

* Added a new `plugin` command group to the CLI and registered it in `src/forge/cli.py`, enabling optional features via CLI commands.
* Implemented `src/forge/commands/plugin_cmd.py`, which provides an `openapi` command to automate OpenAPI support. This command:
  * Detects the project structure and updates `api.py` to include OpenAPI imports and initialization.
  * Creates an extension file for OpenAPI integration.
  * Registers existing controller blueprints with OpenAPI.
  * Provides user feedback and documentation routes.

**Dependency Management:**

* Updated `pyproject.toml` to include `flask_smorest` as a required dependency for OpenAPI support.

These changes make it much easier for users to add OpenAPI documentation and validation to their Flask projects with a single CLI command.